### PR TITLE
feat: update mime version 4.0.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import mime from 'mime/lite.js'
+import mime from 'mime/lite'
 
 /**
  * @class

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"remote"
 	],
 	"dependencies": {
-		"mime": "^3.0.0"
+		"mime": "^4.0.4"
 	},
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
This PR updates mime from v3 to v4.0.4 and makes the required change from `lite.js` to `lite` as defined in the exports for v4: https://github.com/broofa/mime/blame/cfa9bb0e17d02ee8fc8d1e514c3ded274c62245c/package.json#L14C10-L14C10